### PR TITLE
Allow injected dependencies to getController

### DIFF
--- a/ngTestHarness.js
+++ b/ngTestHarness.js
@@ -473,10 +473,14 @@
          * @returns {Object} Controller An angular controller with passed vars and proper scope.
          * @param {string} name The name of the controller.
          * @param {Object} vars Parent scope variables that are merged into the new controller scope.
+         * @param {Object} injected Dependency overrides that are injected into the controller
          */
-        getController: function (name, vars) {
+        getController: function (name, vars, inject) {
             var scope = this.createChildScope(vars);
-            var controller = this.getProvider('$controller')(name, {$scope: scope});
+            var injected = angular.copy(inject || {});
+            injected.$scope = scope;
+
+            var controller = this.getProvider('$controller')(name, injected);
 
             if (controller) {
                 // ensure we can access the newly created scope

--- a/ngTestHarness.js
+++ b/ngTestHarness.js
@@ -473,7 +473,7 @@
          * @returns {Object} Controller An angular controller with passed vars and proper scope.
          * @param {string} name The name of the controller.
          * @param {Object} vars Parent scope variables that are merged into the new controller scope.
-         * @param {Object} injected Dependency overrides that are injected into the controller
+         * @param {Object} inject Dependency overrides that are injected into the controller
          */
         getController: function (name, vars, inject) {
             var scope = this.createChildScope(vars);

--- a/test/ngTestHarness.spec.js
+++ b/test/ngTestHarness.spec.js
@@ -456,4 +456,28 @@ describe('ngTestHarness', function() {
             expect(controller.$scope.message).toBe('Hello');
         });
     });
+
+    describe("getController with injected dependencies",function() {
+        var harness;
+
+        beforeEach(function () {
+            angular.module('test', []).controller('testCtrl',function ($scope, injectMe) {
+                return {
+                    getInjectedMessage: function () {
+                        return injectMe;
+                    }
+                };
+            });
+
+            harness = new ngTestHarness(['test']);
+        });
+
+        it("should inject service when controller created", function() {
+            var injectMe = "Hello Injected";
+            var harness = new ngTestHarness(["test"]);
+            var controller = harness.getController("testCtrl",{},{injectMe:injectMe});
+
+            expect(controller.getInjectedMessage()).toBe("Hello Injected");
+        });
+    });
 });


### PR DESCRIPTION
Currently ngtestHarness does not allow testing of controllers that are instantiated by the $routeProvider with resolve dependencies since resolve could be adding dependencies that don't exist within the injector.

Consider the following code, that calls projectClient.listProjects() which returns a promise for an array of projects.

    $routeProvider.when("/listProjects",  {templateUrl: "/projects/list.html",
                                               controller : "projectListCtrl",
                                               resolve: {
                                                   projects: function(projectClient) {
                                                       return projectClient.listProjects({});
                                                   }
                                               }
                                         });

The service definition would be:

     angular.module("example").controller("projectListCtrl", function($scope, projects) {......}

Of course the dependency _projects_ doesn't exist until after the resolve has completed.  Such a controller in the current ngTestHarness could not be tested as the _projects_ dependency cannot be passed in.

This PR would allow the controller to be tested with 

     var injected = {
           projects: ["project1","project2"]
     }
     var controller = harness.getController("projectListCtrl",{},injected);

I don't really like the fact that _vars_ would have to be an empty object, but I'm not sure there's anyway around that.

